### PR TITLE
query: fix optional params

### DIFF
--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -29,7 +29,7 @@ export const createUseQuery = (
             ts.factory.createPropertySignature(
               undefined,
               ts.factory.createIdentifier(param.name.getText(node)),
-              param.questionToken,
+              param.questionToken ?? param.initializer ? ts.factory.createToken(ts.SyntaxKind.QuestionToken) : param.questionToken,
               param.type
             )
           )

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -29,7 +29,7 @@ export const createUseQuery = (
             ts.factory.createPropertySignature(
               undefined,
               ts.factory.createIdentifier(param.name.getText(node)),
-              undefined,
+              param.questionToken,
               param.type
             )
           )


### PR DESCRIPTION
Optional params are not marked as optional, this is demonstrated already in the repo under the /pets endpoint.

limit and tags are marked as required in the hook when they should be optional.