### PR TITLE
fix(deps): fix breaking peer dep requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ Usage: openapi-rq [options]
 Generate React Query code based on OpenAPI
 
 Options:
-  -V, --version            output the version number
-  -i, --input <value>      OpenAPI specification, can be a path, url or string content (required)
-  -o, --output <value>     Output directory (default: "openapi")
-  -c, --client <value>     HTTP client to generate [fetch, xhr, node, axios, angular] (default: "fetch")
-  --useUnionTypes          Use union types (default: false)
-  --exportSchemas <value>  Write schemas to disk (default: false)
-  --indent <value>         Indentation options [4, 2, tabs] (default: "4")
-  --postfix <value>        Service name postfix (default: "Service")
-  --request <value>        Path to custom request file
-  -h, --help               display help for command
+  -V, --version              output the version number
+  -i, --input <value>        OpenAPI specification, can be a path, url or string content (required)
+  -o, --output <value>       Output directory (default: "openapi")
+  -c, --client <value>       HTTP client to generate [fetch, xhr, node, axios, angular] (default: "fetch")
+  --useUnionTypes            Use union types (default: false)
+  --exportSchemas <value>    Write schemas to disk (default: false)
+  --indent <value>           Indentation options [4, 2, tabs] (default: "4")
+  --postfixServices <value>  Service name postfix (default: "Service")
+  --postfixModels <value>    Modal name postfix
+  --request <value>          Path to custom request file
+  -h, --help                 display help for command
 ```
 
 ## Example Usage

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -9,11 +9,11 @@
     "dev:mock": "prism mock ./petstore.yaml",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "generate:api": "node ../../dist/src/cli.js -i ./petstore.yaml -c axios --exportSchemas=true --postfix=Client --request ./request.ts",
+    "generate:api": "node ../../dist/src/cli.js -i ./petstore.yaml -c axios --exportSchemas=true --postfixServices=Client --request ./request.ts",
     "test:generated": "tsc ./openapi/queries/index.ts --noEmit --target esnext --moduleResolution node"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.28.0",
+    "@tanstack/react-query": "^4.29.1",
     "axios": "^1.3.5",
     "form-data": "~4.0.0",
     "react": "^18.2.0",
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@stoplight/prism-cli": "^4.11.1",
-    "@types/react": "^18.0.33",
+    "@types/react": "^18.0.34",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.0.3",
+    "typescript": "^5.0.4",
     "vite": "^4.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   "devDependencies": {
     "@types/node": "^18.15.11",
     "commander": "^10.0.0",
-    "glob": "^9.3.4",
-    "openapi-typescript-codegen": "^0.23.0",
-    "typescript": "^5.0.3"
+    "glob": "^10.0.0",
+    "openapi-typescript-codegen": "^0.24.0",
+    "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "commander": "> 10",
-    "glob": "> 9",
-    "openapi-typescript-codegen": "^0.23.0",
+    "commander": ">= 10 < 11",
+    "glob": ">= 10",
+    "openapi-typescript-codegen": "^0.24.0",
     "typescript": ">= 4.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
       glob:
-        specifier: ^9.3.4
-        version: 9.3.4
+        specifier: ^10.0.0
+        version: 10.0.0
       openapi-typescript-codegen:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.4
+        version: 5.0.4
 
   dist:
     devDependencies:
@@ -29,20 +29,20 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
       glob:
-        specifier: ^9.3.4
-        version: 9.3.4
+        specifier: ^10.0.0
+        version: 10.0.0
       openapi-typescript-codegen:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.4
+        version: 5.0.4
 
   examples/react-app:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^4.28.0
-        version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^4.29.1
+        version: 4.29.1(react-dom@18.2.0)(react@18.2.0)
       axios:
         specifier: ^1.3.5
         version: 1.3.5
@@ -60,8 +60,8 @@ importers:
         specifier: ^4.11.1
         version: 4.11.1
       '@types/react':
-        specifier: ^18.0.33
-        version: 18.0.33
+        specifier: ^18.0.34
+        version: 18.0.34
       '@types/react-dom':
         specifier: ^18.0.11
         version: 18.0.11
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.4
+        version: 5.0.4
       vite:
         specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
@@ -767,12 +767,12 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /@tanstack/query-core@4.27.0:
-    resolution: {integrity: sha512-sm+QncWaPmM73IPwFlmWSKPqjdTXZeFf/7aEmWh00z7yl2FjqophPt0dE1EHW9P1giMC5rMviv7OUbSDmWzXXA==}
+  /@tanstack/query-core@4.29.1:
+    resolution: {integrity: sha512-vkPewLEG8ua0efo3SsVT0BcBtkq5RZX8oPhDAyKL+k/rdOYSQTEocfGEXSaBwIwsXeOGBUpfKqI+UmHvNqdWXg==}
     dev: false
 
-  /@tanstack/react-query@4.28.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-8cGBV5300RHlvYdS4ea+G1JcZIt5CIuprXYFnsWggkmGoC0b5JaqG0fIX3qwDL9PTNkKvG76NGThIWbpXivMrQ==}
+  /@tanstack/react-query@4.29.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/crv1v+OeuGG6EOvaQmyeo9GCKtH4jbmuhZkvk9ulufRiHcTr/A9+YP9GevEAZzUTdzXMwenpTbyxBGvG2xXvw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -783,7 +783,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@tanstack/query-core': 4.27.0
+      '@tanstack/query-core': 4.29.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-sync-external-store: 1.2.0(react@18.2.0)
@@ -809,11 +809,11 @@ packages:
   /@types/react-dom@18.0.11:
     resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
     dependencies:
-      '@types/react': 18.0.33
+      '@types/react': 18.0.34
     dev: true
 
-  /@types/react@18.0.33:
-    resolution: {integrity: sha512-sHxzVxeanvQyQ1lr8NSHaj0kDzcNiGpILEVt69g9S31/7PfMvNCKLKcsHw4lYKjs3cGNJjXSP4mYzX43QlnjNA==}
+  /@types/react@18.0.34:
+    resolution: {integrity: sha512-NO1UO8941541CJl1BeOXi8a9dNKFK09Gnru5ZJqkm4Q3/WoQJtHvmwt0VX0SB9YCEwe7TfSSxDuaNmx6H2BAIQ==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
@@ -1112,11 +1112,6 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
-    dev: true
-
   /compute-gcd@1.2.1:
     resolution: {integrity: sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==}
     dependencies:
@@ -1413,9 +1408,9 @@ packages:
     resolution: {integrity: sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==}
     dev: true
 
-  /fs-extra@10.1.0:
-    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
-    engines: {node: '>=12'}
+  /fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -1485,14 +1480,14 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /glob@9.3.4:
-    resolution: {integrity: sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==}
+  /glob@10.0.0:
+    resolution: {integrity: sha512-zmp9ZDC6NpDNLujV2W2n+3lH+BafIVZ4/ct+Yj3BMZTH/+bgm/eVjHzeFLwxJrrIGgjjS2eiQLlpurHsNlEAtQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       fs.realpath: 1.0.0
-      minimatch: 8.0.3
-      minipass: 4.2.5
-      path-scurry: 1.6.3
+      minimatch: 9.0.0
+      minipass: 5.0.0
+      path-scurry: 1.6.4
     dev: true
 
   /globals@11.12.0:
@@ -1939,9 +1934,9 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
+  /lru-cache@9.0.1:
+    resolution: {integrity: sha512-C8QsKIN1UIXeOs3iWmiZ1lQY+EnKDojWd37fXy1aSbJvH4iSma1uy2OWuoB3m4SYRli5+CUjDv3Dij5DVoetmg==}
+    engines: {node: 14 || >=16.14}
     dev: true
 
   /magic-string@0.27.0:
@@ -1990,8 +1985,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch@8.0.3:
-    resolution: {integrity: sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==}
+  /minimatch@9.0.0:
+    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -2005,8 +2000,8 @@ packages:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
-  /minipass@4.2.5:
-    resolution: {integrity: sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==}
+  /minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
     dev: true
 
@@ -2123,13 +2118,13 @@ packages:
       format-util: 1.0.5
     dev: true
 
-  /openapi-typescript-codegen@0.23.0:
-    resolution: {integrity: sha512-gOJXy5g3H3HlLpVNN+USrNK2i2KYBmDczk9Xk34u6JorwrGiDJZUj+al4S+i9TXdfUQ/ZaLxE59Xf3wqkxGfqA==}
+  /openapi-typescript-codegen@0.24.0:
+    resolution: {integrity: sha512-rSt8t1XbMWhv6Db7GUI24NNli7FU5kzHLxcE8BpzgGWRdWyWt9IB2YoLyPahxNrVA7yOaVgnXPkrcTDRMQtJYg==}
     hasBin: true
     dependencies:
       camelcase: 6.3.0
-      commander: 9.5.0
-      fs-extra: 10.1.0
+      commander: 10.0.0
+      fs-extra: 11.1.1
       handlebars: 4.7.7
       json-schema-ref-parser: 9.0.9
     dev: true
@@ -2187,12 +2182,12 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
-  /path-scurry@1.6.3:
-    resolution: {integrity: sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==}
+  /path-scurry@1.6.4:
+    resolution: {integrity: sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 7.18.3
-      minipass: 4.2.5
+      lru-cache: 9.0.1
+      minipass: 5.0.0
     dev: true
 
   /path-type@3.0.0:
@@ -2630,8 +2625,8 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typescript@5.0.3:
-    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
+  /typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { Options } from "openapi-typescript-codegen";
 export type CLIOptions = {
   output?: string;
   client?: Options["httpClient"];
-} & Pick<Options, 'exportSchemas' | 'postfix' | 'request' | 'indent' | 'input' | 'useUnionTypes'>;
+} & Pick<Options, 'exportSchemas' | 'postfixModels' | 'postfixServices' | 'request' | 'indent' | 'input' | 'useUnionTypes'>;
 
 const program = new Command();
 
@@ -28,7 +28,8 @@ program
   .option("--useUnionTypes", "Use union types", false)
   .option("--exportSchemas <value>", "Write schemas to disk", false)
   .option("--indent <value>", "Indentation options [4, 2, tabs]", "4")
-  .option("--postfix <value>", "Service name postfix", "Service")
+  .option("--postfixServices <value>", "Service name postfix", "Service")
+  .option("--postfixModels <value>", "Modal name postfix")
   .option("--request <value>", "Path to custom request file")
   .parse();
 

--- a/src/createExports.ts
+++ b/src/createExports.ts
@@ -1,12 +1,12 @@
 import ts from "typescript";
-import glob from "glob";
+import { sync }  from "glob";
 import { join } from "path";
 import fs from "fs";
 import { createUseQuery } from "./createUseQuery";
 import { createUseMutation } from "./createUseMutation";
 
 export const createExports = (generatedClientsPath: string) => {
-  const services = glob.sync(join(generatedClientsPath, 'services', '*.ts').replace(/\\/g, '/'));
+  const services = sync(join(generatedClientsPath, 'services', '*.ts').replace(/\\/g, '/'));
   const nodes = services.map((servicePath) =>
     ts.createSourceFile(
       servicePath, // fileName

--- a/src/createImports.ts
+++ b/src/createImports.ts
@@ -1,10 +1,10 @@
 import ts from "typescript";
-import glob from "glob";
+import { sync } from "glob";
 import { extname, basename, join } from "path";
 
 export const createImports = (generatedClientsPath: string) => {
-  const models = glob.sync(join(generatedClientsPath, 'models', '*.ts').replace(/\\/g, '/'));
-  const services = glob.sync(join(generatedClientsPath, 'services', '*.ts').replace(/\\/g, '/'));
+  const models = sync(join(generatedClientsPath, 'models', '*.ts').replace(/\\/g, '/'));
+  const services = sync(join(generatedClientsPath, 'services', '*.ts').replace(/\\/g, '/'));
   return [
     ts.factory.createImportDeclaration(
       undefined,


### PR DESCRIPTION
This PR fixes an issue where the peer dependencies were listed for versions of packages that did not exist.
An example being `commander > 10`. Version 10 is the latest of commander.

This also updates all dependencies. 

openapi-typescript-codegen updated and changed `postfix` to `postfixServices` and added a new option for `postfixModals`. Added support for those and documented in the README.
^ this could be seen as a breaking change.

Updated glob to version 10. Glob removed default export.
[See commit](https://github.com/isaacs/node-glob/commit/26673b905684f0058c4594be0b4026b8a22544a7)