### PR TITLE
patch(return types): union return type with undefined.

### DIFF
--- a/examples/react-app/petstore.yaml
+++ b/examples/react-app/petstore.yaml
@@ -77,6 +77,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /not-defined:
+    get:
+      description: This path is not fully defined.
+      responses:
+        default:
+          description: unexpected error
   /pets/{id}:
     get:
       description: Returns a user based on a single ID, if the user does not have access to the pet

--- a/examples/react-app/petstore.yaml
+++ b/examples/react-app/petstore.yaml
@@ -79,6 +79,7 @@ paths:
                 $ref: '#/components/schemas/Error'
   /not-defined:
     get:
+      deprecated: true
       description: This path is not fully defined.
       responses:
         default:

--- a/examples/react-app/petstore.yaml
+++ b/examples/react-app/petstore.yaml
@@ -84,6 +84,12 @@ paths:
       responses:
         default:
           description: unexpected error
+    post:
+      deprecated: true
+      description: This path is not defined at all.
+      responses:
+        default:
+          description: unexpected error
   /pets/{id}:
     get:
       description: Returns a user based on a single ID, if the user does not have access to the pet

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -4,6 +4,7 @@ import {
   useDefaultClientFindPets,
   useDefaultClientFindPetsKey,
   useDefaultClientGetNotDefined,
+  useDefaultClientPostNotDefined,
 } from "../openapi/queries";
 import { useState } from "react";
 import { queryClient } from "./queryClient";
@@ -16,7 +17,9 @@ function App() {
 
   // This is an example of a query that is not defined in the OpenAPI spec
   // this defaults to any - here we are showing how to override the type
+  // Note - this is marked as deprecated in the OpenAPI spec and being passed to the client
   const { data: notDefined } = useDefaultClientGetNotDefined<undefined>();
+  const { mutate: mutateNotDefined } = useDefaultClientPostNotDefined<undefined>();
 
   const { mutate: addPet } = useDefaultClientAddPet();
 

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -3,6 +3,7 @@ import {
   useDefaultClientAddPet,
   useDefaultClientFindPets,
   useDefaultClientFindPetsKey,
+  useDefaultClientGetNotDefined,
 } from "../openapi/queries";
 import { useState } from "react";
 import { queryClient } from "./queryClient";
@@ -12,6 +13,10 @@ function App() {
   const [limit, _setLimit] = useState<number>(10);
 
   const { data, error, refetch } = useDefaultClientFindPets({ tags, limit });
+
+  // This is an example of a query that is not defined in the OpenAPI spec
+  // this defaults to any - here we are showing how to override the type
+  const { data: notDefined } = useDefaultClientGetNotDefined<undefined>();
 
   const { mutate: addPet } = useDefaultClientAddPet();
 

--- a/src/createExports.ts
+++ b/src/createExports.ts
@@ -65,7 +65,7 @@ export const createExports = (generatedClientsPath: string) => {
 
             return httpMethodName === "'GET'"
               ? createUseQuery(node, className, method, jsDoc, hasDeprecated)
-              : createUseMutation(node, className, method);
+              : createUseMutation(node, className, method, jsDoc, hasDeprecated);
           })
           .flat();
       })

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { capitalizeFirstLetter } from "./common";
-import { addJSDocToNode } from './util';
+import { addJSDocToNode } from "./util";
 
 export const createUseQuery = (
   node: ts.SourceFile,
@@ -221,37 +221,34 @@ export const createUseQuery = (
                 ts.factory.createObjectLiteralExpression([
                   ts.factory.createPropertyAssignment(
                     ts.factory.createIdentifier("queryKey"),
-                    ts.factory.createAsExpression(
-                      ts.factory.createArrayLiteralExpression(
-                        [
-                          ts.factory.createIdentifier(queryKey),
-                          ts.factory.createSpreadElement(
-                            ts.factory.createParenthesizedExpression(
-                              ts.factory.createBinaryExpression(
-                                ts.factory.createIdentifier("queryKey"),
-                                ts.factory.createToken(
-                                  ts.SyntaxKind.QuestionQuestionToken
-                                ),
-                                method.parameters.length
-                                  ? ts.factory.createArrayLiteralExpression([
-                                      ts.factory.createObjectLiteralExpression(
-                                        method.parameters.map((param) =>
-                                          ts.factory.createShorthandPropertyAssignment(
-                                            ts.factory.createIdentifier(
-                                              param.name.getText(node)
-                                            )
+                    ts.factory.createArrayLiteralExpression(
+                      [
+                        ts.factory.createIdentifier(queryKey),
+                        ts.factory.createSpreadElement(
+                          ts.factory.createParenthesizedExpression(
+                            ts.factory.createBinaryExpression(
+                              ts.factory.createIdentifier("queryKey"),
+                              ts.factory.createToken(
+                                ts.SyntaxKind.QuestionQuestionToken
+                              ),
+                              method.parameters.length
+                                ? ts.factory.createArrayLiteralExpression([
+                                    ts.factory.createObjectLiteralExpression(
+                                      method.parameters.map((param) =>
+                                        ts.factory.createShorthandPropertyAssignment(
+                                          ts.factory.createIdentifier(
+                                            param.name.getText(node)
                                           )
                                         )
-                                      ),
-                                    ])
-                                  : ts.factory.createArrayLiteralExpression([])
-                              )
+                                      )
+                                    ),
+                                  ])
+                                : ts.factory.createArrayLiteralExpression([])
                             )
-                          ),
-                        ],
-                        false
-                      ),
-                      queryKeyGenericType
+                          )
+                        ),
+                      ],
+                      false
                     )
                   ),
                   ts.factory.createPropertyAssignment(

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -43,10 +43,7 @@ export const createUseQuery = (
   const customHookName = `use${className}${capitalizeFirstLetter(methodName)}`;
   const queryKey = `${customHookName}Key`;
 
-  const queryKeyGenericType = ts.factory.createTypeReferenceNode(
-    "TQueryKey",
-    undefined
-  );
+  const queryKeyGenericType = ts.factory.createTypeReferenceNode("TQueryKey");
   const queryKeyConstraint = ts.factory.createTypeReferenceNode("Array", [
     ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
   ]);
@@ -69,219 +66,251 @@ export const createUseQuery = (
       ),
     ]
   );
-
-  const responseDataType = ts.factory.createTypeParameterDeclaration(
-    undefined,
-    "TData",
+  // DefaultResponseDataType
+  const defaultApiResponse = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createIdentifier(
+      `${capitalizeFirstLetter(className)}${capitalizeFirstLetter(
+        methodName
+      )}DefaultResponse`
+    ),
     undefined,
     awaitedResponseDataType
   );
 
-  return [
-    // QueryKey
-    ts.factory.createVariableStatement(
-      [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-      ts.factory.createVariableDeclarationList(
+  const TData = ts.factory.createIdentifier("TData");
+  const TError = ts.factory.createIdentifier("TError");
+
+  const responseDataType = ts.factory.createTypeParameterDeclaration(
+    undefined,
+    TData.text,
+    undefined,
+    ts.factory.createTypeReferenceNode(defaultApiResponse.name)
+  );
+
+  // Omit<UseQueryResult<Awaited<ReturnType<typeof myClass.myMethod>>, TError>, 'data'> & { data: TData|undefined };
+  const responseReturnType = ts.factory.createIntersectionTypeNode([
+    ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Omit"), [
+      ts.factory.createTypeReferenceNode(
+        ts.factory.createIdentifier("UseQueryResult"),
         [
-          ts.factory.createVariableDeclaration(
-            ts.factory.createIdentifier(queryKey),
-            undefined,
-            undefined,
-            ts.factory.createStringLiteral(
-              `${className}${capitalizeFirstLetter(methodName)}`
-            )
-          ),
-        ],
-        ts.NodeFlags.Const
-      )
+          defaultApiResponse.type,
+          ts.factory.createTypeReferenceNode(TError, undefined),
+        ]
+      ),
+      ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral("data")),
+    ]),
+    ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        undefined,
+        ts.factory.createIdentifier("data"),
+        undefined,
+        ts.factory.createUnionTypeNode([
+          ts.factory.createTypeReferenceNode(TData, undefined),
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+        ])
+      ),
+    ]),
+  ]);
+
+  // Return Type
+  const returnTypeExport = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createIdentifier(
+      `${capitalizeFirstLetter(className)}${capitalizeFirstLetter(
+        methodName
+      )}QueryResult`
     ),
-    // Custom hook
-    ts.factory.createVariableStatement(
-      [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-      ts.factory.createVariableDeclarationList(
-        [
-          ts.factory.createVariableDeclaration(
-            ts.factory.createIdentifier(customHookName),
+    [
+      ts.factory.createTypeParameterDeclaration(
+        undefined,
+        TData,
+        undefined,
+        ts.factory.createTypeReferenceNode(defaultApiResponse.name)
+      ),
+      ts.factory.createTypeParameterDeclaration(
+        undefined,
+        TError,
+        undefined,
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
+      ),
+    ],
+    responseReturnType
+  );
+
+  // QueryKey
+  const queryKeyExport = ts.factory.createVariableStatement(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          ts.factory.createIdentifier(queryKey),
+          undefined,
+          undefined,
+          ts.factory.createStringLiteral(
+            `${className}${capitalizeFirstLetter(methodName)}`
+          )
+        ),
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
+  // Custom hook
+  const hookExport = ts.factory.createVariableStatement(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          ts.factory.createIdentifier(customHookName),
+          undefined,
+          undefined,
+          ts.factory.createArrowFunction(
             undefined,
-            undefined,
-            ts.factory.createArrowFunction(
-              undefined,
-              ts.factory.createNodeArray([
-                ts.factory.createTypeParameterDeclaration(
-                  undefined,
-                  "TQueryKey",
-                  queryKeyConstraint,
-                  ts.factory.createArrayTypeNode(
-                    ts.factory.createKeywordTypeNode(
-                      ts.SyntaxKind.UnknownKeyword
-                    )
-                  )
-                ),
-                responseDataType,
-                ts.factory.createTypeParameterDeclaration(
-                  undefined,
-                  "TError",
-                  undefined,
+            ts.factory.createNodeArray([
+              responseDataType,
+              ts.factory.createTypeParameterDeclaration(
+                undefined,
+                TError,
+                undefined,
+                ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
+              ),
+              ts.factory.createTypeParameterDeclaration(
+                undefined,
+                "TQueryKey",
+                queryKeyConstraint,
+                ts.factory.createArrayTypeNode(
                   ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
-                ),
-              ]),
-              [
-                ...requestParam,
-                ts.factory.createParameterDeclaration(
-                  undefined,
-                  undefined,
-                  ts.factory.createIdentifier("queryKey"),
-                  ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-                  queryKeyGenericType
-                ),
-                ts.factory.createParameterDeclaration(
-                  undefined,
-                  undefined,
-                  ts.factory.createIdentifier("options"),
-                  ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-                  ts.factory.createTypeReferenceNode(
-                    ts.factory.createIdentifier("Omit"),
-                    [
-                      ts.factory.createTypeReferenceNode(
-                        ts.factory.createIdentifier("UseQueryOptions"),
-                        [
-                          awaitedResponseDataType,
-                          ts.factory.createKeywordTypeNode(
-                            ts.SyntaxKind.UnknownKeyword
-                          ),
-                          awaitedResponseDataType,
-                          ts.factory.createArrayTypeNode(
-                            ts.factory.createKeywordTypeNode(
-                              ts.SyntaxKind.UnknownKeyword
-                            )
-                          ),
-                        ]
-                      ),
-                      ts.factory.createUnionTypeNode([
-                        ts.factory.createLiteralTypeNode(
-                          ts.factory.createStringLiteral("queryKey")
-                        ),
-                        ts.factory.createLiteralTypeNode(
-                          ts.factory.createStringLiteral("queryFn")
-                        ),
-                        ts.factory.createLiteralTypeNode(
-                          ts.factory.createStringLiteral("initialData")
-                        ),
-                      ]),
-                    ]
-                  )
-                ),
-              ],
-              undefined,
-              ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              ts.factory.createAsExpression(
-                ts.factory.createCallExpression(
-                  ts.factory.createIdentifier("useQuery"),
-                  undefined,
+                )
+              ),
+            ]),
+            [
+              ...requestParam,
+              ts.factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                ts.factory.createIdentifier("queryKey"),
+                ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                queryKeyGenericType
+              ),
+              ts.factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                ts.factory.createIdentifier("options"),
+                ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                ts.factory.createTypeReferenceNode(
+                  ts.factory.createIdentifier("Omit"),
                   [
-                    ts.factory.createObjectLiteralExpression([
-                      ts.factory.createPropertyAssignment(
-                        ts.factory.createIdentifier("queryKey"),
-                        ts.factory.createArrayLiteralExpression(
-                          [
-                            ts.factory.createIdentifier(queryKey),
-                            ts.factory.createSpreadElement(
-                              ts.factory.createParenthesizedExpression(
-                                ts.factory.createBinaryExpression(
-                                  ts.factory.createIdentifier("queryKey"),
-                                  ts.factory.createToken(
-                                    ts.SyntaxKind.QuestionQuestionToken
-                                  ),
-                                  method.parameters.length
-                                    ? ts.factory.createArrayLiteralExpression([
-                                        ts.factory.createObjectLiteralExpression(
-                                          method.parameters.map((param) =>
-                                            ts.factory.createShorthandPropertyAssignment(
-                                              ts.factory.createIdentifier(
-                                                param.name.getText(node)
-                                              )
-                                            )
-                                          )
-                                        ),
-                                      ])
-                                    : ts.factory.createArrayLiteralExpression(
-                                        []
-                                      )
-                                )
-                              )
-                            ),
-                          ],
-                          false
-                        )
+                    ts.factory.createTypeReferenceNode(
+                      ts.factory.createIdentifier("UseQueryOptions"),
+                      [
+                        ts.factory.createTypeReferenceNode(TData),
+                        ts.factory.createTypeReferenceNode(TError),
+                        ts.factory.createTypeReferenceNode(TData),
+                        queryKeyGenericType,
+                      ]
+                    ),
+                    ts.factory.createUnionTypeNode([
+                      ts.factory.createLiteralTypeNode(
+                        ts.factory.createStringLiteral("queryKey")
                       ),
-                      ts.factory.createPropertyAssignment(
-                        ts.factory.createIdentifier("queryFn"),
-                        ts.factory.createArrowFunction(
-                          undefined,
-                          undefined,
-                          [],
-                          undefined,
-                          ts.factory.createToken(
-                            ts.SyntaxKind.EqualsGreaterThanToken
-                          ),
-                          ts.factory.createCallExpression(
-                            ts.factory.createPropertyAccessExpression(
-                              ts.factory.createIdentifier(className),
-                              ts.factory.createIdentifier(methodName)
-                            ),
-                            undefined,
-                            method.parameters.map((param) =>
-                              ts.factory.createIdentifier(
-                                param.name.getText(node)
-                              )
-                            )
-                          )
-                        )
+                      ts.factory.createLiteralTypeNode(
+                        ts.factory.createStringLiteral("queryFn")
                       ),
-                      ts.factory.createSpreadAssignment(
-                        ts.factory.createIdentifier("options")
+                      ts.factory.createLiteralTypeNode(
+                        ts.factory.createStringLiteral("initialData")
                       ),
                     ]),
                   ]
-                ),
-                // Omit<UseQueryResult<Awaited<ReturnType<typeof myClass.myMethod>>, TError>, 'data'> & { data: TData };
-                ts.factory.createIntersectionTypeNode([
-                  ts.factory.createTypeReferenceNode(
-                    ts.factory.createIdentifier("Omit"),
-                    [
-                      ts.factory.createTypeReferenceNode(
-                        ts.factory.createIdentifier("UseQueryResult"),
+                )
+              ),
+            ],
+            undefined,
+            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            ts.factory.createCallExpression(
+              ts.factory.createIdentifier("useQuery"),
+              [
+                ts.factory.createTypeReferenceNode(TData),
+                ts.factory.createTypeReferenceNode(TError),
+                ts.factory.createTypeReferenceNode(TData),
+                queryKeyGenericType,
+              ],
+              [
+                ts.factory.createObjectLiteralExpression([
+                  ts.factory.createPropertyAssignment(
+                    ts.factory.createIdentifier("queryKey"),
+                    ts.factory.createAsExpression(
+                      ts.factory.createArrayLiteralExpression(
                         [
-                          awaitedResponseDataType,
-                          ts.factory.createTypeReferenceNode(
-                            ts.factory.createIdentifier("TError"),
-                            undefined
+                          ts.factory.createIdentifier(queryKey),
+                          ts.factory.createSpreadElement(
+                            ts.factory.createParenthesizedExpression(
+                              ts.factory.createBinaryExpression(
+                                ts.factory.createIdentifier("queryKey"),
+                                ts.factory.createToken(
+                                  ts.SyntaxKind.QuestionQuestionToken
+                                ),
+                                method.parameters.length
+                                  ? ts.factory.createArrayLiteralExpression([
+                                      ts.factory.createObjectLiteralExpression(
+                                        method.parameters.map((param) =>
+                                          ts.factory.createShorthandPropertyAssignment(
+                                            ts.factory.createIdentifier(
+                                              param.name.getText(node)
+                                            )
+                                          )
+                                        )
+                                      ),
+                                    ])
+                                  : ts.factory.createArrayLiteralExpression([])
+                              )
+                            )
                           ),
-                        ]
+                        ],
+                        false
                       ),
-                      ts.factory.createLiteralTypeNode(
-                        ts.factory.createStringLiteral("data")
-                      ),
-                    ]
+                      queryKeyGenericType
+                    )
                   ),
-                  ts.factory.createTypeLiteralNode([
-                    ts.factory.createPropertySignature(
+                  ts.factory.createPropertyAssignment(
+                    ts.factory.createIdentifier("queryFn"),
+                    ts.factory.createArrowFunction(
                       undefined,
-                      ts.factory.createIdentifier("data"),
                       undefined,
-                      ts.factory.createTypeReferenceNode(
-                        ts.factory.createIdentifier("TData"),
-                        undefined
+                      [],
+                      undefined,
+                      ts.factory.createToken(
+                        ts.SyntaxKind.EqualsGreaterThanToken
+                      ),
+                      ts.factory.createAsExpression(
+                        ts.factory.createCallExpression(
+                          ts.factory.createPropertyAccessExpression(
+                            ts.factory.createIdentifier(className),
+                            ts.factory.createIdentifier(methodName)
+                          ),
+                          undefined,
+                          method.parameters.map((param) =>
+                            ts.factory.createIdentifier(
+                              param.name.getText(node)
+                            )
+                          )
+                        ),
+                        ts.factory.createTypeReferenceNode(TData)
                       )
-                    ),
-                  ]),
-                ])
-              )
+                    )
+                  ),
+                  ts.factory.createSpreadAssignment(
+                    ts.factory.createIdentifier("options")
+                  ),
+                ]),
+              ]
             )
-          ),
-        ],
-        ts.NodeFlags.Const
-      )
-    ),
-  ];
+          )
+        ),
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
+  return [defaultApiResponse, returnTypeExport, queryKeyExport, hookExport];
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,44 @@
+import ts from 'typescript';
+
+export function addJSDocToNode<T extends ts.Node>(
+  node: T,
+  sourceFile: ts.SourceFile,
+  deprecated: boolean,
+  jsDoc: (string | ts.NodeArray<ts.JSDocComment> | undefined)[] = [],
+): T {
+  const deprecatedString = deprecated ? "@deprecated" : "";
+
+  const jsDocString = [deprecatedString]
+    .concat(
+      jsDoc.map((comment) => {
+        if (typeof comment === "string") {
+          return comment;
+        }
+        if (Array.isArray(comment)) {
+          return comment.map((c) => c.getText(sourceFile)).join("\n");
+        }
+        return "";
+      })
+    )
+    // remove empty lines
+    .filter(Boolean)
+    // trim
+    .map((comment) => comment.trim())
+    // add * to each line
+    .map((comment) => `* ${comment}`)
+    // join lines
+    .join("\n")
+    // replace new lines with \n *
+    .replace(/\n/g, "\n * ");
+
+  const nodeWithJSDoc = jsDocString
+    ? ts.addSyntheticLeadingComment(
+        node,
+        ts.SyntaxKind.MultiLineCommentTrivia,
+        `*\n ${jsDocString}\n `,
+        true
+      )
+    : node;
+  
+  return nodeWithJSDoc;
+}


### PR DESCRIPTION
React query data is in union with undefined by default.
Previously, we were overriding the default data type of react query.
This causes the issue where the default return type was never marked as undefined.
It should always be possible for the default data to be undefined.

Now we union with undefined.

Exporting the default return type, closes #32

Re-did some of the typings to make it easier to change types.
Added to the example showing how to override the return type for the data, which was addressed in #29

Now, the generator passes the open API descriptions as JSDoc comments to the generated hooks and marks the methods as depreciated if marked in the spec. This closes: #18 

Showing undefined listed in union on return type (as react query would do)
<img width="896" alt="image" src="https://github.com/7nohe/openapi-react-query-codegen/assets/14366926/a5403cbf-12aa-4ab3-aa3e-489c20431185">


New JSDoc:
<img width="1412" alt="image" src="https://github.com/7nohe/openapi-react-query-codegen/assets/14366926/f027c2b3-41b9-4130-b9c7-905cc379c76f">

With deprecated indicator:
<img width="1111" alt="image" src="https://github.com/7nohe/openapi-react-query-codegen/assets/14366926/8aa94812-f349-4651-b2ee-84fad2553930">
 
 
 Exporting helper types for consumers if they need:
 
<img width="1222" alt="image" src="https://github.com/7nohe/openapi-react-query-codegen/assets/14366926/ebd31efa-eea5-4f68-bbce-49e669cfe2c1">
