### PR TITLE
Fix Capitalization on {methodName}MutationResult

### DIFF
--- a/src/createUseMutation.ts
+++ b/src/createUseMutation.ts
@@ -35,7 +35,7 @@ export const createUseMutation = (
 
   const mutationResult = ts.factory.createTypeAliasDeclaration(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-    ts.factory.createIdentifier(`${className}${methodName}MutationResult`),
+    ts.factory.createIdentifier(`${className}${capitalizeFirstLetter(methodName)}MutationResult`),
     undefined,
     awaitedResponseDataType
   );


### PR DESCRIPTION
This PR contains a simple capitalization fix. As you can see from the screenshot below, the `{methodName}MutationResult` results in a poorly cased type, in this case `UserClientcreateMutationResult`. This PR should fix this to produce an expected `UserClientCreateMutationResult`

<img width="776" alt="Screenshot 2024-01-10 at 4 01 00 PM" src="https://github.com/7nohe/openapi-react-query-codegen/assets/5702322/2cec23b2-6bf3-4fb8-9feb-83975686136b">
