### PR TITLE
fix(query): add default parameter initializer

### DIFF
--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -15,6 +15,9 @@ function App() {
   const [limit, _setLimit] = useState<number>(10);
 
   const { data, error, refetch } = useDefaultServiceFindPets({ tags, limit });
+  // This is an example of using a hook that has all parameters optional;
+  // Here we do not have to pass in an object
+  const {} = useDefaultServiceFindPets();
 
   // This is an example of a query that is not defined in the OpenAPI spec
   // this defaults to any - here we are showing how to override the type


### PR DESCRIPTION
This PR adds a default parameter initializer if all the properties of the object are optional.

This is an ease-of-use feature that improves DX.

Fixes: Default empty arguments #37

```tsx
  // if the props tags and limit are optional (using props)
  const { data, error, refetch } = useDefaultServiceFindPets({ tags, limit });
  // before this PR, we would have to pass an object to the hook (not using props)
  const { data, error, refetch } = useDefaultServiceFindPets({});
  // with this PR, we no longer are required to pass an object if all the props are optional (not using props)
  const { data, error, refetch }  = useDefaultServiceFindPets();
```
