### PR TITLE
Warn if no models, instead of throwing an error

### DIFF
--- a/src/createImports.mts
+++ b/src/createImports.mts
@@ -21,8 +21,8 @@ export const createImports = ({
 
   if (!modelsFile) {
     console.warn(`
-WARNING: No models file found.
-This may be an error if you \`.components.schemas\` or \`.components.parameters\` is defined in your OpenAPI input.`);
+⚠️ WARNING: No models file found.
+  This may be an error if \`.components.schemas\` or \`.components.parameters\` is defined in your OpenAPI input.`);
   }
 
   if (!serviceFile) {


### PR DESCRIPTION
Adds a Warning message instead of throwing an error if no `models` file is found.

Ideally, we would check if `components.schemas` or `components.parameters`  is defined, but the OpenAPI definition is not in scope here.

I didn't see prior examples of throwing errors, and I'm very open suggestions on what should be done there instead.

Fixes #66 