### PR TITLE
fix: allow initialData

### DIFF
--- a/src/createUseQuery.mts
+++ b/src/createUseQuery.mts
@@ -305,9 +305,6 @@ function createQueryHook({
                       ts.factory.createLiteralTypeNode(
                         ts.factory.createStringLiteral("queryFn")
                       ),
-                      ts.factory.createLiteralTypeNode(
-                        ts.factory.createStringLiteral("initialData")
-                      ),
                     ]),
                   ]
                 )


### PR DESCRIPTION
This PR allows initialData to be set on the hooks and passed to useQuery.

I am unsure why we initially added it to the omit list.
I believe it was to type it so we could override the types.

It seems the types now propagate the override type to initialData.

I haven't done a lot of testing on this to be specific.

If someone has time to test this build, that would be great.

Fixes #68 