### PR TITLE
fix(enums): take in and pass correct values to service generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options:
   -c, --client <value>       HTTP client to generate [fetch, xhr, node, axios, angular] (default: "fetch")
   --request <value>          Path to custom request file
   --useDateType              Use Date type instead of string for date types for models, this will not convert the data to a Date object
-  --enums                    Generate JavaScript objects from enum definitions?
+  --enums <value>            Generate JavaScript objects from enum definitions? ['javascript', 'typescript']
   --base <value>             Manually set base in OpenAPI config instead of inferring from server value
   --serviceResponse <value>  Define shape of returned value from service calls ['body', 'generics', 'response']
   --operationId              Use operation ID to generate operation names?

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -45,7 +45,12 @@ async function setupProgram() {
       "--base <value>",
       "Manually set base in OpenAPI config instead of inferring from server value"
     )
-    .option("--enums", "Generate JavaScript objects from enum definitions?")
+    .addOption(
+      new Option(
+        "--enums <value>",
+        "Generate JavaScript objects from enum definitions?"
+      ).choices(["javascript", "typescript"])
+    )
     .option(
       "--useDateType",
       "Use Date type instead of string for date types for models, this will not convert the data to a Date object"
@@ -54,7 +59,7 @@ async function setupProgram() {
 
   const options = program.opts<LimitedUserConfig>();
 
-  generate(options, version);
+  await generate(options, version);
 }
 
 setupProgram();

--- a/src/generate.mts
+++ b/src/generate.mts
@@ -25,6 +25,8 @@ export async function generate(options: UserConfig, version: string) {
         (acc as any)[typedKey] = true;
       } else if (value === "false") {
         (acc as any)[typedKey] = false;
+      } else {
+        (acc as any)[typedKey] = typedValue;
       }
       return acc;
     },


### PR DESCRIPTION
In this PR, we correctly accept a value for the enums property and pass it to the the underlying service generator.

Fixes: #72 