### PR TITLE
feat: add query key function

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,75 @@ function App() {
 export default App;
 ```
 
+##### Using Mutation hooks
+
+```tsx
+// App.tsx
+import { usePetServiceAddPet } from "../openapi/queries";
+
+function App() {
+  const { mutate } = usePetServiceAddPet();
+
+  const handleAddPet = () => {
+    mutate({ name: "Fluffy", status: "available" });
+  };
+
+  return (
+    <div className="App">
+      <h1>Add Pet</h1>
+      <button onClick={handleAddPet}>Add Pet</button>
+    </div>
+  );
+}
+
+export default App;
+```
+
+##### Invalidating queries after mutation
+
+Invalidating queries after a mutation is important to ensure the cache is updated with the new data. This is done by calling the `queryClient.invalidateQueries` function with the query key used by the query hook.
+
+Learn more about invalidating queries [here](https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation).
+
+To ensure the query key is created the same way as the query hook, you can use the query key function exported by the generated query hooks.
+
+```tsx
+import {
+  usePetServiceFindPetsByStatus,
+  usePetServiceAddPet,
+  UsePetServiceFindPetsByStatusKeyFn,
+} from "../openapi/queries";
+
+// App.tsx
+function App() {
+  const { data } = usePetServiceFindPetsByStatus({ status: ["available"] });
+  const { mutate } = usePetServiceAddPet({
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        // Call the query key function to get the query key, this is important to ensure the query key is created the same way as the query hook, this insures the cache is invalidated correctly and is typed correctly
+        queryKey: [UsePetServiceFindPetsByStatusKeyFn()],
+      });
+    },
+  });
+
+  return (
+    <div className="App">
+      <h1>Pet List</h1>
+      <ul>{data?.map((pet) => <li key={pet.id}>{pet.name}</li>)}</ul>
+      <button
+        onClick={() => {
+          mutate({ name: "Fluffy", status: "available" });
+        }}
+      >
+        Add Pet
+      </button>
+    </div>
+  );
+}
+
+export default App;
+```
+
 ##### Runtime Configuration
 
 You can modify the default values used by the generated service calls by modifying the OpenAPI configuration singleton object.

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -2,7 +2,7 @@ import "./App.css";
 import {
   useDefaultServiceAddPet,
   useDefaultServiceFindPets,
-  useDefaultServiceFindPetsKey,
+  UseDefaultServiceFindPetsKeyFn,
   useDefaultServiceGetNotDefined,
   useDefaultServicePostNotDefined,
 } from "../openapi/queries";
@@ -54,7 +54,7 @@ function App() {
             {
               onSuccess: () => {
                 queryClient.invalidateQueries({
-                  queryKey: [useDefaultServiceFindPetsKey],
+                  queryKey: UseDefaultServiceFindPetsKeyFn(),
                 });
                 console.log("success");
               },

--- a/src/common.mts
+++ b/src/common.mts
@@ -15,6 +15,14 @@ export const TData = ts.factory.createIdentifier("TData");
 export const TError = ts.factory.createIdentifier("TError");
 export const TContext = ts.factory.createIdentifier("TContext");
 
+export const EqualsOrGreaterThanToken = ts.factory.createToken(
+  ts.SyntaxKind.EqualsGreaterThanToken
+);
+
+export const QuestionToken = ts.factory.createToken(
+  ts.SyntaxKind.QuestionToken
+);
+
 export const queryKeyGenericType =
   ts.factory.createTypeReferenceNode("TQueryKey");
 export const queryKeyConstraint = ts.factory.createTypeReferenceNode("Array", [

--- a/src/createExports.mts
+++ b/src/createExports.mts
@@ -40,7 +40,12 @@ export const createExports = (service: Service) => {
   ];
 
   const commonInQueries = allQueries
-    .map(({ apiResponse, returnType, key }) => [apiResponse, returnType, key])
+    .map(({ apiResponse, returnType, key, queryKeyFn }) => [
+      apiResponse,
+      returnType,
+      key,
+      queryKeyFn,
+    ])
     .flat();
   const commonInMutations = allMutations
     .map(({ mutationResult }) => [mutationResult])

--- a/tests/__snapshots__/createSource.test.ts.snap
+++ b/tests/__snapshots__/createSource.test.ts.snap
@@ -17,12 +17,20 @@ import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 export type DefaultServiceFindPetsDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPets>>;
 export type DefaultServiceFindPetsQueryResult<TData = DefaultServiceFindPetsDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetsKey = "DefaultServiceFindPets";
+export const UseDefaultServiceFindPetsKeyFn = ({ limit, tags }: {
+    limit?: number;
+    tags?: string[];
+} = {}, queryKey?: Array<unknown>) => [useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])];
 export type DefaultServiceGetNotDefinedDefaultResponse = Awaited<ReturnType<typeof DefaultService.getNotDefined>>;
 export type DefaultServiceGetNotDefinedQueryResult<TData = DefaultServiceGetNotDefinedDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceGetNotDefinedKey = "DefaultServiceGetNotDefined";
+export const UseDefaultServiceGetNotDefinedKeyFn = () => [useDefaultServiceGetNotDefinedKey];
 export type DefaultServiceFindPetByIdDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPetById>>;
 export type DefaultServiceFindPetByIdQueryResult<TData = DefaultServiceFindPetByIdDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetByIdKey = "DefaultServiceFindPetById";
+export const UseDefaultServiceFindPetByIdKeyFn = ({ id }: {
+    id: number;
+}, queryKey?: Array<unknown>) => [useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])];
 export type DefaultServiceAddPetMutationResult = Awaited<ReturnType<typeof DefaultService.addPet>>;
 export type DefaultServicePostNotDefinedMutationResult = Awaited<ReturnType<typeof DefaultService.postNotDefined>>;
 export type DefaultServiceDeletePetMutationResult = Awaited<ReturnType<typeof DefaultService.deletePet>>;
@@ -52,14 +60,14 @@ import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 export const useDefaultServiceFindPets = <TData = Common.DefaultServiceFindPetsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ limit, tags }: {
     limit?: number;
     tags?: string[];
-} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])], queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
+} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetsKeyFn({ limit, tags }, queryKey), queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
 /**
 * @deprecated
 * This path is not fully defined.
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])], queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -70,7 +78,7 @@ export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetN
 */
 export const useDefaultServiceFindPetById = <TData = Common.DefaultServiceFindPetByIdDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ id }: {
     id: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])], queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetByIdKeyFn({ id }, queryKey), queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
 /**
 * Creates a new pet in the store. Duplicates are allowed
 * @param data The data for the request.
@@ -130,14 +138,14 @@ import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 export const useDefaultServiceFindPetsSuspense = <TData = Common.DefaultServiceFindPetsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ limit, tags }: {
     limit?: number;
     tags?: string[];
-} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])], queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
+} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetsKeyFn({ limit, tags }, queryKey), queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
 /**
 * @deprecated
 * This path is not fully defined.
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])], queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -148,7 +156,7 @@ export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultSer
 */
 export const useDefaultServiceFindPetByIdSuspense = <TData = Common.DefaultServiceFindPetByIdDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ id }: {
     id: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])], queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetByIdKeyFn({ id }, queryKey), queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
 "
 `;
 

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -8,12 +8,20 @@ import { DefaultService } from "../requests/services.gen";
 export type DefaultServiceFindPetsDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPets>>;
 export type DefaultServiceFindPetsQueryResult<TData = DefaultServiceFindPetsDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetsKey = "DefaultServiceFindPets";
+export const UseDefaultServiceFindPetsKeyFn = ({ limit, tags }: {
+  limit?: number;
+  tags?: string[];
+} = {}, queryKey?: Array<unknown>) => [useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])];
 export type DefaultServiceGetNotDefinedDefaultResponse = Awaited<ReturnType<typeof DefaultService.getNotDefined>>;
 export type DefaultServiceGetNotDefinedQueryResult<TData = DefaultServiceGetNotDefinedDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceGetNotDefinedKey = "DefaultServiceGetNotDefined";
+export const UseDefaultServiceGetNotDefinedKeyFn = () => [useDefaultServiceGetNotDefinedKey];
 export type DefaultServiceFindPetByIdDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPetById>>;
 export type DefaultServiceFindPetByIdQueryResult<TData = DefaultServiceFindPetByIdDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetByIdKey = "DefaultServiceFindPetById";
+export const UseDefaultServiceFindPetByIdKeyFn = ({ id }: {
+  id: number;
+}, queryKey?: Array<unknown>) => [useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])];
 export type DefaultServiceAddPetMutationResult = Awaited<ReturnType<typeof DefaultService.addPet>>;
 export type DefaultServicePostNotDefinedMutationResult = Awaited<ReturnType<typeof DefaultService.postNotDefined>>;
 export type DefaultServiceDeletePetMutationResult = Awaited<ReturnType<typeof DefaultService.deletePet>>;
@@ -94,14 +102,14 @@ import * as Common from "./common";
 export const useDefaultServiceFindPets = <TData = Common.DefaultServiceFindPetsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ limit, tags }: {
   limit?: number;
   tags?: string[];
-} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])], queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
+} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetsKeyFn({ limit, tags }, queryKey), queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
 /**
 * @deprecated
 * This path is not fully defined.
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])], queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -112,7 +120,7 @@ export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetN
 */
 export const useDefaultServiceFindPetById = <TData = Common.DefaultServiceFindPetByIdDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ id }: {
   id: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])], queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetByIdKeyFn({ id }, queryKey), queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
 /**
 * Creates a new pet in the store. Duplicates are allowed
 * @param data The data for the request.
@@ -171,14 +179,14 @@ import * as Common from "./common";
 export const useDefaultServiceFindPetsSuspense = <TData = Common.DefaultServiceFindPetsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ limit, tags }: {
   limit?: number;
   tags?: string[];
-} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetsKey, ...(queryKey ?? [{ limit, tags }])], queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
+} = {}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetsKeyFn({ limit, tags }, queryKey), queryFn: () => DefaultService.findPets({ limit, tags }) as TData, ...options });
 /**
 * @deprecated
 * This path is not fully defined.
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])], queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -189,6 +197,6 @@ export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultSer
 */
 export const useDefaultServiceFindPetByIdSuspense = <TData = Common.DefaultServiceFindPetByIdDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ id }: {
   id: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: [Common.useDefaultServiceFindPetByIdKey, ...(queryKey ?? [{ id }])], queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceFindPetByIdKeyFn({ id }, queryKey), queryFn: () => DefaultService.findPetById({ id }) as TData, ...options });
 "
 `;

--- a/tests/createExports.test.ts
+++ b/tests/createExports.test.ts
@@ -5,7 +5,7 @@ import { createExports } from "../src/createExports.mts";
 import { getServices } from "../src/service.mts";
 import path from "path";
 
-const fileName = "createExports"
+const fileName = "createExports";
 
 describe(fileName, () => {
   beforeAll(async () => await generateTSClients(fileName));
@@ -15,12 +15,12 @@ describe(fileName, () => {
     const project = new Project({
       skipAddingFilesFromTsConfig: true,
     });
-    project.addSourceFilesAtPaths(path.join(outputPath(fileName), '**', '*'));
+    project.addSourceFilesAtPaths(path.join(outputPath(fileName), "**", "*"));
     const service = await getServices(project);
     const exports = createExports(service);
 
     const commonTypes = exports.allCommon
-    .filter((c) => c.kind === SyntaxKind.TypeAliasDeclaration)
+      .filter((c) => c.kind === SyntaxKind.TypeAliasDeclaration)
       // @ts-ignore
       .map((e) => e.name.escapedText);
     expect(commonTypes).toStrictEqual([
@@ -36,13 +36,16 @@ describe(fileName, () => {
     ]);
 
     const constants = exports.allCommon
-    .filter((c) => c.kind === SyntaxKind.VariableStatement)
-    // @ts-ignore
+      .filter((c) => c.kind === SyntaxKind.VariableStatement)
+      // @ts-ignore
       .map((c) => c.declarationList.declarations[0].name.escapedText);
     expect(constants).toStrictEqual([
       "useDefaultServiceFindPetsKey",
+      "UseDefaultServiceFindPetsKeyFn",
       "useDefaultServiceGetNotDefinedKey",
+      "UseDefaultServiceGetNotDefinedKeyFn",
       "useDefaultServiceFindPetByIdKey",
+      "UseDefaultServiceFindPetByIdKeyFn",
     ]);
 
     const mainExports = exports.mainExports.map(


### PR DESCRIPTION
This PR is to make it easier for consumers to invalidate queries.

This is achieved by exporting a new function that builds the query keys.
This function is used internally to build the queryKey for the hooks.

The new functions are the name of the `queryHook + key + 'Fn'` and the first letter is capitalized.

We capitalize the first letter because the lowercase 'use' is reserved for hooks and all our `queryHook` start with use.

```tsx
// example
import {
  usePetServiceFindPetsByStatus,
  usePetServiceAddPet,
  UsePetServiceFindPetsByStatusKeyFn,
} from "../openapi/queries";
import React from 'react';

// App.tsx
function App() {
  const [status, setStatus] = React.useState('available');
  const { data } = usePetServiceFindPetsByStatus({ status });
  const { mutate } = usePetServiceAddPet({
    onSuccess: () => {
      queryClient.invalidateQueries({
        // Call the query key function to get the query key
        // this is important to ensure the query key is created the same way as the query hook,
        // this insures the cache is invalidated correctly.
        queryKey: [UsePetServiceFindPetsByStatusKeyFn({
          status,
        })],
      });
    },
  });

  return (
    <div className="App">
      <h1>Pet List</h1>
      <ul>{data?.map((pet) => <li key={pet.id}>{pet.name}</li>)}</ul>
      <button
        onClick={() => {
          mutate({ name: "Fluffy", status: "available" });
        }}
      >
        Add Pet
      </button>
    </div>
  );
}

export default App;
```