### PR TITLE
fix(cli): set serviceResponse default value to body

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options:
   --format <value>           Process output folder with formatter? ['biome', 'prettier']
   --lint   <value>           Process output folder with linter? ['eslint', 'biome']
   --operationId              Use operation ID to generate operation names?
-  --serviceResponse <value>  Define shape of returned value from service calls ['body', 'response']
+  --serviceResponse <value>  Define shape of returned value from service calls ['body', 'response'] (default: "body")
   --base <value>             Manually set base in OpenAPI config instead of inferring from server value
   --enums <value>            Generate JavaScript objects from enum definitions? ['javascript', 'typescript']
   --useDateType              Use Date type instead of string for date types for models, this will not convert the data to a Date object

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -64,7 +64,9 @@ async function setupProgram() {
       new Option(
         "--serviceResponse <value>",
         "Define shape of returned value from service calls"
-      ).choices(["body", "response"])
+      )
+        .choices(["body", "response"])
+        .default("body")
     )
     .option(
       "--base <value>",


### PR DESCRIPTION
We set this so that the default request file returns the request's body instead of the whole response object.

This changed in the underlying library at some point, so we must update our default value to match.


fixes: #95 

As this library relies on the response being the body, maybe we should think of disabling allowing consumers to change that option. Something to think about.