### PR TITLE
ci: update comment-release workflow

### DIFF
--- a/.github/workflows/comment-release.yml
+++ b/.github/workflows/comment-release.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ⬇️ Checkout PR
+        run: |
+          git fetch origin pull/${{ github.event.issue.number }}/head:pr-find-commit
+          git checkout pr-find-commit
+
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
@@ -50,13 +55,15 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo }, payload  } = context;
             const { name: packageName, version } = require(`${process.env.GITHUB_WORKSPACE}/package.json`);
 
+            const body = [
+              `npm package published to pre tag.`,
+              `\`\`\`bash\nnpm install ${packageName}@pre\n\`\`\``
+              `\`\`\`bash\nnpm install ${packageName}@${version}\n\`\`\``
+            ].join('\n\n');
+
             await github.rest.issues.updateComment({
               owner,
               repo,
               comment_id: payload.comment.id,
-              body: [
-                `npm package published to pre tag.`,
-                `\`\`\`bash\nnpm install ${packageName}@pre\n\`\`\``
-                `\`\`\`bash\nnpm install ${packageName}@${version}\n\`\`\``
-              ].join('\n\n'),
+              body,
             });


### PR DESCRIPTION
This changes the npm versioning to use the git sha of the current PR and not the main branch.



There is some bug in the comment-release workflow when updating the github comment.

Getting errors saying `packageName is not a function`

I am trying to understand why that is happening.

https://github.com/7nohe/openapi-react-query-codegen/actions/runs/8888225124/job/24404700180