### PR TITLE
fix(prefetch): import QueryClient type

### DIFF
--- a/src/createImports.mts
+++ b/src/createImports.mts
@@ -44,6 +44,11 @@ export const createImports = ({
         undefined,
         ts.factory.createNamedImports([
           ts.factory.createImportSpecifier(
+            true,
+            undefined,
+            ts.factory.createIdentifier("QueryClient")
+          ),
+          ts.factory.createImportSpecifier(
             false,
             undefined,
             ts.factory.createIdentifier("useQuery")

--- a/tests/__snapshots__/createSource.test.ts.snap
+++ b/tests/__snapshots__/createSource.test.ts.snap
@@ -11,7 +11,7 @@ export * from "./queries";
 exports[`createSource > createSource 2`] = `
 "// generated with @7nohe/openapi-react-query-codegen@1.0.0 
 
-import { useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import { type QueryClient, useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { DefaultService } from "../requests/services.gen";
 import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 export type DefaultServiceFindPetsDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPets>>;
@@ -41,7 +41,7 @@ exports[`createSource > createSource 3`] = `
 "// generated with @7nohe/openapi-react-query-codegen@1.0.0 
 
 import * as Common from "./common";
-import { useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import { type QueryClient, useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { DefaultService } from "../requests/services.gen";
 import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 /**
@@ -119,7 +119,7 @@ exports[`createSource > createSource 4`] = `
 "// generated with @7nohe/openapi-react-query-codegen@1.0.0 
 
 import * as Common from "./common";
-import { useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import { type QueryClient, useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { DefaultService } from "../requests/services.gen";
 import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 /**
@@ -164,7 +164,7 @@ exports[`createSource > createSource 5`] = `
 "// generated with @7nohe/openapi-react-query-codegen@1.0.0 
 
 import * as Common from "./common";
-import { useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import { type QueryClient, useQuery, useSuspenseQuery, useMutation, UseQueryResult, UseQueryOptions, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { DefaultService } from "../requests/services.gen";
 import { Pet, NewPet, Error, $OpenApiTs } from "../requests/types.gen";
 /**

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -39,6 +39,7 @@ export * from "./queries";
 exports[`generate > prefetch.ts 1`] = `
 "// generated with @7nohe/openapi-react-query-codegen@1.0.0 
 
+import { type QueryClient } from "@tanstack/react-query";
 import { DefaultService } from "../requests/services.gen";
 import * as Common from "./common";
 /**


### PR DESCRIPTION
In some instances, the QueryClient import was not auto-detected by ts-morph.

The fix is to - Explicitly add the type import.

ts-morph doesn't seem to have an issue removing the import if it is not being used in a file.