### PR TITLE
fix: Use optional query keys also without parameters

### DIFF
--- a/src/createUseQuery.mts
+++ b/src/createUseQuery.mts
@@ -347,7 +347,7 @@ export function createQueryHook({
                             ),
                             ts.factory.createIdentifier("queryKey"),
                           ]
-                        : [],
+                        : [ts.factory.createIdentifier("queryKey")],
                     ),
                   ),
                   ts.factory.createPropertyAssignment(
@@ -490,7 +490,7 @@ function createQueryKeyFnExport(queryKey: string, method: MethodDeclaration) {
           ts.factory.createArrowFunction(
             undefined,
             undefined,
-            params ? [params, overrideKey] : [],
+            params ? [params, overrideKey] : [overrideKey],
             undefined,
             EqualsOrGreaterThanToken,
             queryKeyFn(queryKey, method),
@@ -506,14 +506,6 @@ function queryKeyFn(
   queryKey: string,
   method: MethodDeclaration,
 ): ts.Expression {
-  const params = getRequestParamFromMethod(method);
-
-  if (!params) {
-    return ts.factory.createArrayLiteralExpression([
-      ts.factory.createIdentifier(queryKey),
-    ]);
-  }
-
   return ts.factory.createArrayLiteralExpression(
     [
       ts.factory.createIdentifier(queryKey),

--- a/tests/__snapshots__/createSource.test.ts.snap
+++ b/tests/__snapshots__/createSource.test.ts.snap
@@ -24,7 +24,7 @@ export const UseDefaultServiceFindPetsKeyFn = ({ limit, tags }: {
 export type DefaultServiceGetNotDefinedDefaultResponse = Awaited<ReturnType<typeof DefaultService.getNotDefined>>;
 export type DefaultServiceGetNotDefinedQueryResult<TData = DefaultServiceGetNotDefinedDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceGetNotDefinedKey = "DefaultServiceGetNotDefined";
-export const UseDefaultServiceGetNotDefinedKeyFn = () => [useDefaultServiceGetNotDefinedKey];
+export const UseDefaultServiceGetNotDefinedKeyFn = (queryKey?: Array<unknown>) => [useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])];
 export type DefaultServiceFindPetByIdDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPetById>>;
 export type DefaultServiceFindPetByIdQueryResult<TData = DefaultServiceFindPetByIdDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetByIdKey = "DefaultServiceFindPetById";
@@ -67,7 +67,7 @@ export const useDefaultServiceFindPets = <TData = Common.DefaultServiceFindPetsD
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(queryKey), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -145,7 +145,7 @@ export const useDefaultServiceFindPetsSuspense = <TData = Common.DefaultServiceF
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(queryKey), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -15,7 +15,7 @@ export const UseDefaultServiceFindPetsKeyFn = ({ limit, tags }: {
 export type DefaultServiceGetNotDefinedDefaultResponse = Awaited<ReturnType<typeof DefaultService.getNotDefined>>;
 export type DefaultServiceGetNotDefinedQueryResult<TData = DefaultServiceGetNotDefinedDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceGetNotDefinedKey = "DefaultServiceGetNotDefined";
-export const UseDefaultServiceGetNotDefinedKeyFn = () => [useDefaultServiceGetNotDefinedKey];
+export const UseDefaultServiceGetNotDefinedKeyFn = (queryKey?: Array<unknown>) => [useDefaultServiceGetNotDefinedKey, ...(queryKey ?? [])];
 export type DefaultServiceFindPetByIdDefaultResponse = Awaited<ReturnType<typeof DefaultService.findPetById>>;
 export type DefaultServiceFindPetByIdQueryResult<TData = DefaultServiceFindPetByIdDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useDefaultServiceFindPetByIdKey = "DefaultServiceFindPetById";
@@ -110,7 +110,7 @@ export const useDefaultServiceFindPets = <TData = Common.DefaultServiceFindPetsD
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefined = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(queryKey), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.
@@ -187,7 +187,7 @@ export const useDefaultServiceFindPetsSuspense = <TData = Common.DefaultServiceF
 * @returns unknown unexpected error
 * @throws ApiError
 */
-export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
+export const useDefaultServiceGetNotDefinedSuspense = <TData = Common.DefaultServiceGetNotDefinedDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>(queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseDefaultServiceGetNotDefinedKeyFn(queryKey), queryFn: () => DefaultService.getNotDefined() as TData, ...options });
 /**
 * Returns a user based on a single ID, if the user does not have access to the pet
 * @param data The data for the request.


### PR DESCRIPTION
The query key functions for queries that don't take in additional request parameters don't allow for using additional query key input, but query hooks always take in a query key parameter. This leads to the query key parameter in hooks without additional input being unused variable, leading to TypeScript erroring. Fix this by always taking query key parameter in query key functions, and always using it in query hooks.

Fixes #112.