### PR TITLE
fix: Ensure that `getShortType` regex wildcard is non-greedy

### DIFF
--- a/src/common.mts
+++ b/src/common.mts
@@ -116,7 +116,7 @@ export function extractPropertiesFromObjectParam(param: ParameterDeclaration) {
  * TODO: Replace with a more robust solution.
  */
 export function getShortType(type: string) {
-  return type.replaceAll(/import\(".*"\)\./g, "");
+  return type.replaceAll(/import\(".*?"\)\./g, "");
 }
 
 export function getClassesFromService(node: SourceFile) {

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -80,6 +80,15 @@ describe("common", () => {
       const result = getShortType(type);
       expect(result).toBe("MyType");
     });
+
+    test("json", () => {
+      const type =
+        '{ import1?: import("/path/to/import1").Import1; import2: import("/path/to/import2").Import2; import3: import("/path/to/import3").Import3; }';
+      const result = getShortType(type);
+      expect(result).toBe(
+        "{ import1?: Import1; import2: Import2; import3: Import3; }",
+      );
+    });
   });
 
   test("formatOptions - converts string boolean to boolean (false)", () => {


### PR DESCRIPTION
Hello!  First, let me thank you for writing this library!  Please enjoy a cup of coffee on me!

We use your library for a project at my company and it's made our lives a lot easier!  We've been using `v0.5.3` for a while, but as part of another effort, I'm updating to `v1.4.1`.  I noticed that some of our OAPI documents are tripping up the react query codegen and wanted to investigate.

I forked your repo and built it locally (which btw required some liberal use of `any` casting to get the project to build on my M3 mac--node 20, TS 5.5.x--but I removed all of those before committing my fix).  I threw in some `console.logs` in `createUseMutation`, and in the `methodParameters` section, `refParam.type.getText(param)` was returning something  in the following shape (paths, param names and type names edited, of course):

```plaintext
'{ type1?: import("/path/to/project/requests/types.gen").Type1; type2: import("/path/to/project/requests/types.gen").Type2; type3: import("/path/to/project/types.gen").Type3; }'
```

This was producing a mutation type signature that looked like this:

```tsx
export const useDefaultServiceMyEndpoint = <
  TData = Common.DefaultServiceMyEndpointMutationResult,
  TError = unknown,
  TContext = unknown,
>(
  options?: Omit<
    UseMutationOptions<
      TData,
      TError,
      {
        companyId: number
        requestBody: {
          type1?: Type3
        }
      },
      TContext
    >,
    'mutationFn'
  >,
) => ...
```

As you can see, it's setting `type1`'s type to `Type3`, which is incorrect.  I discovered that the wildcard in `getShortType` was greedy, and that making it non-greedy would indeed fix the problem.  I included a test with data in the same shape as my case.

Barring any issues with the PR, it would be very helpful for us if we could get this releases ASAP.  Please let me know if there's anything further you need from me!