### PR TITLE
Adding support for nested nextPageParam keys

### DIFF
--- a/src/createUseQuery.mts
+++ b/src/createUseQuery.mts
@@ -655,9 +655,18 @@ function createInfiniteQueryParams(pageParam?: string, nextPageParam?: string) {
           ts.factory.createParenthesizedExpression(
             ts.factory.createAsExpression(
               ts.factory.createIdentifier("response"),
-              ts.factory.createTypeReferenceNode(
-                ts.factory.createIdentifier(`{ ${nextPageParam}: number }`),
-              ),
+              nextPageParam.split(".").reduceRight((acc, segment) => {
+                return ts.factory.createTypeLiteralNode([
+                  ts.factory.createPropertySignature(
+                    undefined,
+                    ts.factory.createIdentifier(segment),
+                    undefined,
+                    acc,
+                  ),
+                ]);
+              }, ts.factory.createKeywordTypeNode(
+                ts.SyntaxKind.NumberKeyword,
+              ) as ts.TypeNode),
             ),
           ),
           ts.factory.createIdentifier(nextPageParam),

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -62,7 +62,13 @@ import * as Common from "./common";
 export const useDefaultServiceFindPaginatedPetsInfinite = <TData = InfiniteData<Common.DefaultServiceFindPaginatedPetsDefaultResponse>, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ limit, tags }: {
   limit?: number;
   tags?: string[];
-} = {}, queryKey?: TQueryKey, options?: Omit<UseInfiniteQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useInfiniteQuery({ queryKey: Common.UseDefaultServiceFindPaginatedPetsKeyFn({ limit, tags }, queryKey), queryFn: ({ pageParam }) => DefaultService.findPaginatedPets({ limit, page: pageParam as number, tags }) as TData, initialPageParam: 1, getNextPageParam: response => (response as { nextPage: number }).nextPage, ...options });
+} = {}, queryKey?: TQueryKey, options?: Omit<UseInfiniteQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useInfiniteQuery({
+  queryKey: Common.UseDefaultServiceFindPaginatedPetsKeyFn({ limit, tags }, queryKey), queryFn: ({ pageParam }) => DefaultService.findPaginatedPets({ limit, page: pageParam as number, tags }) as TData, initialPageParam: 1, getNextPageParam: response => (response as {
+    meta: {
+      nextPage: number;
+    };
+  }).meta.nextPage, ...options
+});
 "
 `;
 

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -20,7 +20,7 @@ describe("generate", () => {
       output: path.join("tests", "outputs"),
       lint: "eslint",
       pageParam: "page",
-      nextPageParam: "nextPage",
+      nextPageParam: "meta.nextPage",
     };
     await generate(options, "1.0.0");
   });


### PR DESCRIPTION
When `nextPageParam` is set to `meta.nextPage`, split on `.` and generate the appropriately nested typehint:

```ts
  getNextPageParam: response => (response as {
    meta: {
      nextPage: number;
    };
  }).meta.nextPage
```

Fixes #142.