### PR TITLE
fix: add `ts-morph` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "@hey-api/client-fetch": "0.4.0",
     "@hey-api/openapi-ts": "0.53.8",
-    "cross-spawn": "^7.0.3"
+    "cross-spawn": "^7.0.3",
+    "ts-morph": "^23.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",
@@ -59,13 +60,11 @@
     "commander": "^12.0.0",
     "lefthook": "^1.6.10",
     "rimraf": "^5.0.5",
-    "ts-morph": "^23.0.0",
     "typescript": "^5.5.4",
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
     "commander": "12.x",
-    "ts-morph": "23.x",
     "typescript": "5.x"
   },
   "packageManager": "pnpm@9.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       cross-spawn:
         specifier: ^7.0.3
         version: 7.0.3
+      ts-morph:
+        specifier: ^23.0.0
+        version: 23.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.3
@@ -39,9 +42,6 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.7
-      ts-morph:
-        specifier: ^23.0.0
-        version: 23.0.0
       typescript:
         specifier: ^5.5.4
         version: 5.6.2


### PR DESCRIPTION

During CLI execution of `openapi-react-query-codegen`, the library uses `ts-morph` as part of its internal process (as you can see [here](https://www.npmjs.com/package/@7nohe/openapi-react-query-codegen?activeTab=code)). However, `ts-morph` was not included as a dependency, which could lead to runtime issues when executing the CLI.

Alternatively, if adding `ts-morph` as a dependency feels burdensome, it may be helpful to include installation instructions for `ts-morph` in the documentation.